### PR TITLE
Fixed password length validation bug

### DIFF
--- a/password_checker.py
+++ b/password_checker.py
@@ -4,7 +4,7 @@ def check_password_strength(password):
     strength = "Weak"
 
     # BUG 1: Length condition wrong (should be >= 8)
-    if len(password) > 8:
+    if len(password) >= 8:
         strength = "Medium"
 
     # BUG 2: Uppercase check incorrect


### PR DESCRIPTION
Updated the length condition to >= 8 so passwords with exactly 8 characters are accepted.

Fixes #1
